### PR TITLE
w3c remove attribute type for script tag

### DIFF
--- a/src/views/async.php
+++ b/src/views/async.php
@@ -5,7 +5,7 @@
  */
 ?>
 <!-- Yandex.Metrika counter -->
-<script type="text/javascript">
+<script>
     (function (d, w, c) {
         (w[c] = w[c] || []).push(function () {
             try {

--- a/src/views/sync.php
+++ b/src/views/sync.php
@@ -5,8 +5,8 @@
  */
 ?>
 <!-- Yandex.Metrika counter -->
-<script src="//mc.yandex.ru/metrika/watch.js" type="text/javascript"></script>
-<script type="text/javascript">
+<script src="//mc.yandex.ru/metrika/watch.js"></script>
+<script>
     try {
         var yaCounter<?= $counterId ?> = new Ya.Metrika(<?=\yii\helpers\Json::encode($counterParams)?>);
     } catch (e) {


### PR DESCRIPTION
For now attribute "type" for script tag is unnecessary for JavaScript resources.